### PR TITLE
feat: add pr review approval protection to release branches

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,12 @@
 repository:
   default_branch: master
 
+branches:
+  - name: *
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+
 teams:
   - { name: 'cli-team',     permission: 'admin' }
   - { name: 'robot-write',  permission: 'admin' }


### PR DESCRIPTION
Adds config for preventing merges of PR's without review approval.

See: https://github.com/npm/statusboard/issues/18