### PR TITLE
fix: turns out you have to allow the files too

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -1,9 +1,9 @@
-# ignore everything
-*
+# ignore everything in the root
+/*
 
 # keep these
 !/.github
-!*/.gitignore
+!**/.gitignore
 !/package.json
 !/package-lock.json
 !/bin


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
🤦 again.

we were excluding the directories we wanted to keep from the gitignore, but because of the ignored `*` that alone wasn't specific enough to allow the files within the directories to be kept. this change explicitly allows the files contained within the directories as well as the directories themselves.