### PR TITLE
fix: do not fail-fast in the CI matrix

### DIFF
--- a/files/ci.yml
+++ b/files/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [10.0.x, 10.x, 12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
         platform:


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
since we test different platforms (and also have a few places where intermittent test failures are known to occur) it seems best to not cancel all of the builds in the matrix when one of them fails.
