### PR TITLE
fix: only run ci for pushes when they are to main or latest

### DIFF
--- a/files/ci.yml
+++ b/files/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - latest
 
 jobs:
   build:


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
there's really no need for us to run the full matrix for everything, let's just test the pull_request event since that's the result of merging the pull request into its target, and the push event for our primary branches as a safe guard

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
