### PR TITLE
feat: keep the npm cache around

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - latest
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [10.0.x, 10.x, 12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
         platform:
@@ -14,6 +20,8 @@ jobs:
           shell: bash
         - os: windows-latest
           shell: bash
+        - os: windows-latest
+          shell: cmd
         - os: windows-latest
           shell: powershell
 
@@ -27,12 +35,13 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: Use Nodejs ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
 
       - name: Update npm
-        run: npm i -g npm@latest
+        run: npm i --prefer-online -g npm@latest
 
       - name: Install dependencies
         run: npm ci

--- a/files/ci.yml
+++ b/files/ci.yml
@@ -21,6 +21,8 @@ jobs:
         - os: windows-latest
           shell: bash
         - os: windows-latest
+          shell: cmd
+        - os: windows-latest
           shell: powershell
 
     runs-on: ${{ matrix.platform.os }}
@@ -33,12 +35,13 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: Use Nodejs ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
 
       - name: Update npm
-        run: npm i -g npm@latest
+        run: npm i --prefer-online -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
turns out v2 of actions/setup-node has caching built in so this took no additional work at all

i also added 'cmd' to the shells we test in windows, and added the `--prefer-online` flag to the npm update to make sure it's always installing the absolute newest thing it can

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
